### PR TITLE
Works around 'Forbidden (CSRF token missing...)

### DIFF
--- a/lists/views.py
+++ b/lists/views.py
@@ -1,5 +1,7 @@
 from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
 
+@csrf_exempt
 # Create your views here.
 def home_page(request):
     return render(request, 'home.html')


### PR DESCRIPTION
Works around the "Forbidden (CSRF token missing or incorrect.): /"

With following combination:
MacOSX 10.11.6 (15G1421)
geckodriver 0.16.1
Python 3.6.1
FF version 53
selenium 3.4.1
Django 1.11