### PR TITLE
Create session server side using a view.

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r'^send_login_email$', views.send_login_email, name='send_login_email'),
     url(r'^login$', views.login, name='login'),
     url(r'^logout$', logout, {'next_page': '/'}, name='logout'),
+    url(r'^ft_login/$', views.ft_login, name='ft_login'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -32,3 +32,9 @@ def login(request):
         auth.login(request, user)
     return redirect('/')
 
+
+def ft_login(request):
+    User = auth.get_user_model()
+    user = User.objects.create(email=request.GET.get('email'))
+    auth.login(request, user)
+    return redirect('/')

--- a/functional_tests/test_my_lists.py
+++ b/functional_tests/test_my_lists.py
@@ -8,19 +8,7 @@ User = get_user_model()
 class MyListsTest(FunctionalTest):
 
     def create_pre_authenticated_session(self, email):
-        user = User.objects.create(email=email)
-        session = SessionStore()
-        session[SESSION_KEY] = user.pk
-        session[BACKEND_SESSION_KEY] = settings.AUTHENTICATION_BACKENDS[0]
-        session.save()
-        ## to set a cookie we need to first visit the domain.
-        ## 404 pages load the quickest!
-        self.browser.get(self.live_server_url + "/404_no_such_url/")
-        self.browser.add_cookie(dict(
-            name=settings.SESSION_COOKIE_NAME,
-            value=session.session_key,
-            path='/',
-        ))
+        self.browser.get(self.live_server_url + "/accounts/ft_login/?email=" + email)
 
 
     def test_logged_in_users_lists_are_saved_as_my_lists(self):


### PR DESCRIPTION
@hjwp, my main motivation for this PR is, IMHO, an unnecessary complexity to create a session for Selenium.

As Zen of Python says: 

> Simple is better than complex.
> Complex is better than complicated.
> ...
> If the implementation is hard to explain, it's a bad idea.

As we discussed by email, `TestCase.Client.force_login()` cannot be used because we're using Selenium here, not Django test client.

My proposal is `accounts.views.ft_login` being a valid route only in development and staging. It could depend on a similar env var, as used in chapter 21 (`STAGING_SERVER`), to tell application where it is running (staging/dev) and activate it.

So, if I am right, this will eliminate the management command to create sessions in chap 21 and simplify your approach a little bit.

BTW, I actually don't expect you to accept this PR because it needs more polishement. Let's consider ir a prove of concept.
