### PR TITLE
Add gunicorn to required packages in provision.ansible.yaml

### DIFF
--- a/deploy_tools/provision.ansible.yaml
+++ b/deploy_tools/provision.ansible.yaml
@@ -11,7 +11,7 @@
       apt_repository:
         repo='ppa:fkrull/deadsnakes'
     - name: make sure required packages are installed
-      apt: pkg=nginx,git,python3.6,python3.6-venv state=present
+      apt: pkg=nginx,git,gunicorn,python3.6,python3.6-venv state=present
 
     - name: allow long hostnames in nginx
       lineinfile: 


### PR DESCRIPTION
I managed to successfully run this Ansible playbook on a Vagrant VM. One issue I had, however, was an error on the 'restart gunicorn' handler. I noticed that gunicorn wasn't listed in provision.ansible.yaml's required packages list. Once I added it, everything checked out.